### PR TITLE
Update host xxh home after config loading

### DIFF
--- a/xxh_xxh/xxh.py
+++ b/xxh_xxh/xxh.py
@@ -748,6 +748,8 @@ class xxh:
 
         local_xxh_home_parent = self.local_xxh_home.parent
 
+        self.host_xxh_home = opt.host_xxh_home
+
         if self.local_xxh_home.exists():
             if not os.access(self.local_xxh_home, os.W_OK):
                 self.eeprint(f"The local xxh home path isn't writable: {self.local_xxh_home}" )


### PR DESCRIPTION
fix #89.

xxh loads `self.host_xxh_home` from `opt.host_xxh_home` at xxh.py line 597.
https://github.com/xxh/xxh/blob/87c1ca5969d852eef1beba2548c36ca802bfc8f8/xxh_xxh/xxh.py#L597
But the variable is not updated after loading config file and `opt`, 
https://github.com/xxh/xxh/blob/87c1ca5969d852eef1beba2548c36ca802bfc8f8/xxh_xxh/xxh.py#L660