### PR TITLE
Quote SSH arguments

### DIFF
--- a/xxh_xxh/shell.py
+++ b/xxh_xxh/shell.py
@@ -14,9 +14,16 @@ def SC(cmd):
     [out, err] = proc.communicate()
     return (out, err, proc)
 
-def A(args, q=0):
+def A(args, q=0, i=0):
     if type(args) == list:
-        args = ' '.join([str(a) for a in args])
+        if i == 1:
+            args = ' '.join([f"'{a}'" for a in args])
+        elif i == 2:
+            args = ' '.join([f'"{a}"' for a in args])
+        elif i == 3:
+            args = ' '.join([f'\\"{a}\\"' for a in args])
+        else:
+            args = ' '.join([str(a) for a in args])
     if q == 1:
         return f"'{args}'"
     elif q == 2:

--- a/xxh_xxh/xxh.py
+++ b/xxh_xxh/xxh.py
@@ -261,7 +261,7 @@ class xxh:
             echo scp=`command -v scp`
             echo shell=`command -v {short_shell_name}`
             echo kernel=`uname -s`
-            echo arch=`uname -m`            
+            echo arch=`uname -m`
             """.format(
                 host_xxh_home=self.host_xxh_home,
                 shell=self.shell,
@@ -708,7 +708,7 @@ class xxh:
             opt.ssh_login = url.username
         if opt.ssh_login:
             username = opt.ssh_login
-        
+
         self.ssh_command = opt.ssh_command
         self.ssh_arguments = ['-o', 'StrictHostKeyChecking=accept-new']
         if not self.verbose:

--- a/xxh_xxh/xxh.py
+++ b/xxh_xxh/xxh.py
@@ -284,7 +284,7 @@ class xxh:
                     host_info_s=host_info_s.strip().replace('\n','\\n').replace('"','\\"').replace('$','\\$').replace('`','\\`'),
                     ssh=self.ssh_command,
                     ssh_v=('' if not self.ssh_arg_v else '-v'),
-                    ssh_arguments=A(self.ssh_arguments),
+                    ssh_arguments=A(self.ssh_arguments, 0, 2),
                     host=host
                 )
 
@@ -318,7 +318,7 @@ class xxh:
                 sshpass=A(self.sshpass),
                 ssh=A(self.ssh_command),
                 ssh_arg_v=A(self.ssh_arg_v),
-                ssh_arguments=A(self.ssh_arguments),
+                ssh_arguments=A(self.ssh_arguments, 0, 2),
                 host=A(host)
             ))
             r = o.strip()
@@ -809,7 +809,7 @@ class xxh:
                 sshpass=A(self.sshpass),
                 ssh=A(self.ssh_command),
                 ssh_arg_v=A(self.ssh_arg_v),
-                ssh_arguments=A(self.ssh_arguments),
+                ssh_arguments=A(self.ssh_arguments, 0, 2),
                 host=A(host)
             )
 
@@ -951,7 +951,7 @@ class xxh:
                     sshpass=A(self.sshpass),
                     ssh=A(self.ssh_command),
                     ssh_arg_v=('' if self.ssh_arg_v == [] else '-v'),
-                    ssh_arguments=A(self.ssh_arguments),
+                    ssh_arguments=A(self.ssh_arguments, 0, 3),
                     arg_q=A(arg_q),
                     progress=('' if self.quiet or not self.verbose else '--progress')
                 )
@@ -982,7 +982,7 @@ class xxh:
                     sshpass=A(self.sshpass),
                     scp_command=A(self.scp_command),
                     ssh_arg_v=A(self.ssh_arg_v),
-                    ssh_arguments=A(self.ssh_arguments),
+                    ssh_arguments=A(self.ssh_arguments, 0, 1),
                     arg_q=A(arg_q)
                 )
 
@@ -1079,7 +1079,7 @@ class xxh:
                 sshpass=A(self.sshpass),
                 ssh=A(self.ssh_command),
                 ssh_arg_v=A(self.ssh_arg_v),
-                ssh_arguments=A(self.ssh_arguments),
+                ssh_arguments=A(self.ssh_arguments, 0, 1),
                 host=A(host),
                 entrypoint_command=entrypoint_command
             ))


### PR DESCRIPTION
## Summary

This PR fixes shell quotation issues where SSH arguments were not properly passed to intended commands if they contain space(s).

In the following example, a user connects to server2 whose connection is required to be established against a proxy (server1).

## get\_host\_info (pexpect)

### Current Behaviour

| Command | # | Argument                                                                          |
|---------|---|-----------------------------------------------------------------------------------|
| bash    | 1 | -c                                                                                |
| bash    | 2 | echo -e "..." \| ssh -v -o ProxyCommand=ssh -W %h:%p server1 server2 -T "bash -s" |

| Command | # | Argument         |
|---------|---|------------------|
| ssh     | 1 | -v               |
| ssh     | 2 | -o               |
| ssh     | 3 | ProxyCommand=ssh |
| ssh     | 4 | -W               |
| ssh     | 5 | %h:%p            |
| ssh     | 6 | server1          |
| ssh     | 7 | server2          |
| ssh     | 8 | -T               |
| ssh     | 9 | bash -s          |

### Expected Behaviour

| Command | # | Argument                                                                              |
|---------|---|---------------------------------------------------------------------------------------|
| bash    | 1 | -c                                                                                    |
| bash    | 2 | echo -e "..." \| ssh -v "-o" "ProxyCommand=ssh -W %h:%p server1" server2 -T "bash -s" |

| Command | # | Argument                          |
|---------|---|-----------------------------------|
| ssh     | 1 | -v                                |
| ssh     | 2 | -o                                |
| ssh     | 3 | ProxyCommand=ssh -W %h:%p server1 |
| ssh     | 4 | server2                           |
| ssh     | 5 | -T                                |
| ssh     | 6 | bash -s                           |

## get\_host\_info (without pexpect)

### Current Behaviour

| Command | # | Argument                                                                          |
|---------|---|-----------------------------------------------------------------------------------|
| bash    | 1 | -c                                                                                |
| bash    | 2 | echo -e "..." \| ssh -v -o ProxyCommand=ssh -W %h:%p server1 server2 -T "bash -s" |

| Command | # | Argument         |
|---------|---|------------------|
| ssh     | 1 | -v               |
| ssh     | 2 | -o               |
| ssh     | 3 | ProxyCommand=ssh |
| ssh     | 4 | -W               |
| ssh     | 5 | %h:%p            |
| ssh     | 6 | server1          |
| ssh     | 7 | server2          |
| ssh     | 8 | -T               |
| ssh     | 9 | bash -s          |

### Expected Behaviour

| Command | # | Argument                                                                              |
|---------|---|---------------------------------------------------------------------------------------|
| bash    | 1 | -c                                                                                    |
| bash    | 2 | echo -e "..." \| ssh -v "-o" "ProxyCommand=ssh -W %h:%p server1" server2 -T "bash -s" |

| Command | # | Argument                          |
|---------|---|-----------------------------------|
| ssh     | 1 | -v                                |
| ssh     | 2 | -o                                |
| ssh     | 3 | ProxyCommand=ssh -W %h:%p server1 |
| ssh     | 4 | server2                           |
| ssh     | 5 | -T                                |
| ssh     | 6 | bash -s                           |

## prepare\_env\_args (ssh)

| Command | # | Argument                                                                       |
|---------|---|--------------------------------------------------------------------------------|
| bash    | 1 | -c                                                                             |
| bash    | 2 | echo "..." \| ssh -v -o ProxyCommand=ssh -W %h:%p server1 server2 -T "bash -s" |

| Command | # | Argument         |
|---------|---|------------------|
| ssh     | 1 | -v               |
| ssh     | 2 | -o               |
| ssh     | 3 | ProxyCommand=ssh |
| ssh     | 4 | -W               |
| ssh     | 5 | %h:%p            |
| ssh     | 6 | server1          |
| ssh     | 7 | server2          |
| ssh     | 8 | -T               |
| ssh     | 9 | bash -s          |

### Expected Behaviour

| Command | # | Argument                                                                           |
|---------|---|------------------------------------------------------------------------------------|
| bash    | 1 | -c                                                                                 |
| bash    | 2 | echo "..." \| ssh -v "-o" "ProxyCommand=ssh -W %h:%p server1" server2 -T "bash -s" |

| Command | # | Argument                          |
|---------|---|-----------------------------------|
| ssh     | 1 | -v                                |
| ssh     | 2 | -o                                |
| ssh     | 3 | ProxyCommand=ssh -W %h:%p server1 |
| ssh     | 4 | server2                           |
| ssh     | 5 | -T                                |
| ssh     | 6 | bash -s                           |

## prepare\_env\_args (rsync)

### Current Behaviour

| Command | # | Argument                                                                                                                                   |
|---------|---|--------------------------------------------------------------------------------------------------------------------------------------------|
| bash    | 1 | -c                                                                                                                                         |
| bash    | 2 | shopt -s dotglob && rsync -v -e "ssh -v -o ProxyCommand=ssh -W %h:%p server1" -az --cvs-exclude --include core build/ server2:build/ 1\>&2 |

| Command | #  | Argument                                    |
|---------|----|---------------------------------------------|
| rsync   | 1  | -v                                          |
| rsync   | 2  | -e                                          |
| rsync   | 3  | ssh -v -o ProxyCommand=ssh -W %h:%p server1 |
| rsync   | 4  | -az                                         |
| rsync   | 5  | --cvs-exclude                               |
| rsync   | 6  | --include                                   |
| rsync   | 7  | core                                        |
| rsync   | 8  | build/                                      |
| rsync   | 9  | server2:build/                              |

| Command | # | Argument         |
|---------|---|------------------|
| ssh     | 1 | -v               |
| ssh     | 2 | -o               |
| ssh     | 3 | ProxyCommand=ssh |
| ssh     | 4 | -W               |
| ssh     | 5 | %h:%p            |
| ssh     | 6 | server1          |

### Expected Behaviour

| Command | # | Argument                                                                                                                                               |
|---------|---|--------------------------------------------------------------------------------------------------------------------------------------------------------|
| bash    | 1 | -c                                                                                                                                                     |
| bash    | 2 | shopt -s dotglob && rsync -v -e "ssh -v \\"-o\\" \\"ProxyCommand=ssh -W %h:%p server1\\"" -az --cvs-exclude --include core build/ server2:build/ 1\>&2 |

| Command | # | Argument                                        |
|---------|---|-------------------------------------------------|
| rsync   | 1 | -v                                              |
| rsync   | 2 | -e                                              |
| rsync   | 3 | ssh -v "-o" "ProxyCommand=ssh -W %h:%p server1" |
| rsync   | 4 | -az                                             |
| rsync   | 5 | --cvs-exclude                                   |
| rsync   | 6 | --include                                       |
| rsync   | 7 | core                                            |
| rsync   | 8 | build/                                          |
| rsync   | 9 | server2:build/                                  |

| Command | # | Argument                          |
|---------|---|-----------------------------------|
| ssh     | 1 | -v                                |
| ssh     | 2 | -o                                |
| ssh     | 3 | ProxyCommand=ssh -W %h:%p server1 |

## prepare\_env\_args (scp)

### Current Behaviour

| Command | # | Argument                                                                                         |
|---------|---|--------------------------------------------------------------------------------------------------|
| bash    | 1 | -c                                                                                               |
| bash    | 2 | shopt -s dotglob && scp -v -o ProxyCommand=ssh -W %h:%p server1 -r -C build server2:build/ 1\>&2 |

| Command | #  | Argument         |
|---------|----|------------------|
| scp     | 1  | -v               |
| scp     | 2  | -o               |
| scp     | 3  | ProxyCommand=ssh |
| scp     | 4  | -W               |
| scp     | 5  | %h:%p            |
| scp     | 6  | server1          |
| scp     | 7  | -r               |
| scp     | 8  | -C               |
| scp     | 9  | build            |
| scp     | 10 | server2:build/   |

### Expected Behaviour

| Command | # | Argument                                                                                             |
|---------|---|------------------------------------------------------------------------------------------------------|
| bash    | 1 | -c                                                                                                   |
| bash    | 2 | shopt -s dotglob && scp -v '-o' 'ProxyCommand=ssh -W %h:%p server1' -r -C build server2:build/ 1\>&2 |

| Command | # | Argument                          |
|---------|---|-----------------------------------|
| scp     | 1 | -v                                |
| scp     | 2 | -o                                |
| scp     | 3 | ProxyCommand=ssh -W %h:%p server1 |
| scp     | 4 | -r                                |
| scp     | 5 | -C                                |
| scp     | 6 | build                             |
| scp     | 7 | server2:build/                    |

## prepare\_env\_args (entrypoint)

### Current Behaviour

| Command | # | Argument         |
|---------|---|------------------|
| ssh     | 1 | -v               |
| ssh     | 2 | -o               |
| ssh     | 3 | ProxyCommand=ssh |
| ssh     | 4 | -W               |
| ssh     | 5 | %h:%p            |
| ssh     | 6 | server1          |
| ssh     | 7 | server2          |
| ssh     | 8 | -T               |
| ssh     | 9 | bash -s          |

### Expected Behaviour

| Command | # | Argument                          |
|---------|---|-----------------------------------|
| ssh     | 1 | -v                                |
| ssh     | 2 | -o                                |
| ssh     | 3 | ProxyCommand=ssh -W %h:%p server1 |
| ssh     | 4 | server2                           |
| ssh     | 5 | -T                                |
| ssh     | 6 | bash -s                           |