### PR TITLE
Handle difference in base64 on MacOS

### DIFF
--- a/xxh/xxh_xxh/xxh.zsh
+++ b/xxh/xxh_xxh/xxh.zsh
@@ -9,23 +9,33 @@ local_xxh_home=~/.xxh
 
 eargs=""
 setopt +o nomatch
-for pluginenv_file in $local_xxh_home/.xxh/plugins/*-zsh-*/env; do
+for pluginenv_file in "$local_xxh_home"/.xxh/plugins/*-zsh-*/env; do
   if [[ -f $pluginenv_file ]]; then
-    plugin_name=$(basename `dirname $pluginenv_file` | tr a-z A-Z | sed 's/-/_/g')
+    plugin_name=$(basename "$(dirname "$pluginenv_file")" | tr "[:lower:]" "[:upper:]" | sed 's/-/_/g')
 
     if [[ $XXH_VERBOSE == '1' || $XXH_VERBOSE == '2' ]]; then
-      echo Load plugin env $pluginenv_file
+      echo Load plugin env "$pluginenv_file"
     fi
 
-    for l in `cat $pluginenv_file`
+    for l in $(cat "$pluginenv_file")
     do
       if [[ -v $l ]]; then
-        d=`declare -p $l | base64 --wrap=0`
-        dd="export $plugin_name"_EXE_"$l=$d"
-        ddd=`echo $dd | base64 --wrap=0`
+        case $(uname -s) in
+          Darwin)
+          #  bas64 in macos uses -b (break) instead of --wrap, and it's 0 by default
+            d=$(declare -p "$l" | base64)
+            dd="export $plugin_name"_EXE_"$l=$d"
+            ddd=$(echo "$dd" | base64)
+          ;;
+          *)
+            d=$(declare -p "$l" | base64 --wrap=0)
+            dd="export $plugin_name"_EXE_"$l=$d"
+            ddd=$(echo "$dd" | base64 --wrap=0)
+          ;;
+        esac
         if [[ $XXH_VERBOSE == '2' ]]; then
-          echo Prepare plugin env $pluginenv_file: name=$l, declare=$d
-          echo Prepare plugin env $pluginenv_file bash: $dd
+          echo Prepare plugin env "$pluginenv_file": name="$l", declare="$d"
+          echo Prepare plugin env "$pluginenv_file" bash: "$dd"
         fi
         eargs="$eargs +heb $ddd"
       fi
@@ -35,5 +45,6 @@ done
 setopt -o nomatch
 
 CDIR="$(cd "$(dirname "$0")" && pwd)"
-[ -f $CDIR/xxh ] && xxh=$CDIR/xxh || xxh='xxh'
-$xxh +s xxh-shell-zsh ${(z)eargs} "$@"
+[ -f "$CDIR"/xxh ] && xxh="$CDIR"/xxh || xxh='xxh'
+# shellcheck disable=SC2296
+$xxh +s xxh-shell-zsh "${(z)eargs}" "$@"


### PR DESCRIPTION
+ bas64 in macos uses -b (break) instead of --wrap, and it's 0 by default
+ ran the file through shellcheck, implemented some of the improvements to handle unexpected glob expansion and a few others
Fixes https://github.com/xxh/xxh/issues/123