### PR TITLE
Don't ignore `++pexpect-timeout` value in config file

### DIFF
--- a/xxh/xxh_xxh/xxh.py
+++ b/xxh/xxh_xxh/xxh.py
@@ -695,6 +695,7 @@ class xxh:
 
         self.verbose = opt.verbose
         self.vverbose = opt.vverbose
+        self.pexpect_timeout = int(opt.pexpect_timeout)
         self.use_pexpect = not opt.pexpect_disable
 
         self.quiet = opt.quiet


### PR DESCRIPTION
This PR fixes #141.

xxh forgets to update `++pexpect-timeout` value after loading config file. This is the same as #90.

## Test result

- `~/config.xxhc`
```yaml
hosts:
    testsrv:
        +s: zsh
        ++pexpect-timeout: '30'
```

- Before

```text
❯ xxh testsrv ++xxh-config ~/config.xxhc +vv
Load xxh config from /home/i/config.xxhc
Load xxh config for host testsrv
Final arguments list: ['+s', 'zsh', '++pexpect-timeout', '30', 'testsrv', '++xxh-config', '/home/i/config.xxhc', '+vv']
ssh arguments: ['-o', 'StrictHostKeyChecking=accept-new']
RUN SHELL COMMAND: mkdir -v -p /home/i/.xxh /home/i/.xxh/.xxh/plugins /home/i/.xxh/.xxh/shells
Pexpect command (timeout=6): bash -c 'echo -e "xxh_home_realpath=\$(dirname ~/.xxh)/\$(basename ~/.xxh)\n            xxh_version=\"dir_not_found\"\n            if [[ -d \$xxh_home_realpath ]]; then\n                xxh_version=\$([ \"\$(ls -A \$xxh_home_realpath)\" ] && echo \"version_not_found\" || echo \"dir_empty\")\n                settings_path=\$xxh_home_realpath/.xxh/xxh_version\n                if [[ -f \$settings_path ]]; then\n                    xxh_version=\$(cat \$settings_path)\n                fi\n            fi\n            echo xxh_home_realpath=\$xxh_home_realpath\n
  echo xxh_version=\$xxh_version\n            echo xxh_shell_exists=\`[ -d \$xxh_home_realpath/.xxh/shells/xxh-shell-zsh ] && echo \"1\" ||echo \"0\"\`\n            echo xxh_home_writable=\`[ -w \$xxh_home_realpath ] && echo \"1\" ||echo \"0\"\`\n            echo xxh_parent_home_writable=\$([ -w \$(dirname \$xxh_home_realpath) ] && echo \"1\" ||echo \"0\")\n            echo rsync=\`command -v rsync\`\n            echo scp=\`command -v scp\`\n            echo shell=\`command -v zsh\`\n            echo kernel=\`uname -s\`\n            echo arch=\`uname -m\`" | ssh -v "-o" "StrictHostKeyChecking=accept-new" testsrv -T "bash -s"'
```

`Pexpect command (timeout=6)` shows that xxh ignores `++pexpect-timeout` value in config file.

- After

```text
❯ ./xxh testsrv ++xxh-config ~/config.xxhc +vv
Load xxh config from /home/i/config.xxhc
Load xxh config for host testsrv
Final arguments list: ['+s', 'zsh', '++pexpect-timeout', '30', 'testsrv', '++xxh-config', '/home/i/config.xxhc', '+vv']
ssh arguments: ['-o', 'StrictHostKeyChecking=accept-new']
RUN SHELL COMMAND: mkdir -v -p /home/i/.xxh /home/i/.xxh/.xxh/plugins /home/i/.xxh/.xxh/shells
Pexpect command (timeout=30): bash -c 'echo -e "xxh_home_realpath=\$(dirname ~/.xxh)/\$(basename ~/.xxh)\n            xxh_version=\"dir_not_found\"\n            if [[ -d \$xxh_home_realpath ]]; then\n                xxh_version=\$([ \"\$(ls -A \$xxh_home_realpath)\" ] && echo \"version_not_found\" || echo \"dir_empty\")\n                settings_path=\$xxh_home_realpath/.xxh/xxh_version\n                if [[ -f \$settings_path ]]; then\n                    xxh_version=\$(cat \$settings_path)\n                fi\n            fi\n            echo xxh_home_realpath=\$xxh_home_realpath\n
   echo xxh_version=\$xxh_version\n            echo xxh_shell_exists=\`[ -d \$xxh_home_realpath/.xxh/shells/xxh-shell-zsh ] && echo \"1\" ||echo \"0\"\`\n            echo xxh_home_writable=\`[ -w \$xxh_home_realpath ] && echo \"1\" ||echo \"0\"\`\n            echo xxh_parent_home_writable=\$([ -w \$(dirname \$xxh_home_realpath) ] && echo \"1\" ||echo \"0\")\n            echo rsync=\`command -v rsync\`\n            echo scp=\`command -v scp\`\n            echo shell=\`command -v zsh\`\n            echo kernel=\`uname -s\`\n            echo arch=\`uname -m\`" | ssh -v "-o" "StrictHostKeyChecking=accept-new" testsrv -T "bash -s"'
```

`Pexpect command (timeout=30)` shows that xxh uses `++pexpect-timeout` value in config file.