### PR TITLE
fix SyntaxWarning on python 3.12

### DIFF
--- a/xxh/xxh_xxh/xxh.py
+++ b/xxh/xxh_xxh/xxh.py
@@ -42,7 +42,7 @@ class xxh:
         self.supported_source_types = ['git', 'path']
         self.supported_xxh_packages_regex = '|'.join(self.supported_xxh_packages)
         self.supported_source_types_regex = '|'.join(self.supported_source_types)
-        self.package_name_regex = f'xxh\-({self.supported_xxh_packages_regex})-[a-zA-Z0-9_-]+'
+        self.package_name_regex = rf'xxh\-({self.supported_xxh_packages_regex})-[a-zA-Z0-9_-]+'
         self.destination_exists = False
         self.local = False
 
@@ -437,7 +437,7 @@ class xxh:
         package_source_type='git'
         package_source=f'https://github.com/xxh/{package_name}'
 
-        g = re.match(f'^({self.package_name_regex})\+({self.supported_source_types_regex})\+(.+)$', package_name)
+        g = re.match(rf'^({self.package_name_regex})\+({self.supported_source_types_regex})\+(.+)$', package_name)
         if g:
             package_name = g.group(1)
             package_source_type = g.group(3)


### PR DESCRIPTION
```console
$ python3.12 -m compileall -f  $(git ls-files '*.py')
Compiling 'xde/tests/xonsh/test_env.py'...
Compiling 'xxh/xxh_xxh/__init__.py'...
Compiling 'xxh/xxh_xxh/shell.py'...
Compiling 'xxh/xxh_xxh/xxh.py'...
xxh/xxh_xxh/xxh.py:45: SyntaxWarning: invalid escape sequence '\-'
  self.package_name_regex = f'xxh\-({self.supported_xxh_packages_regex})-[a-zA-Z0-9_-]+'
xxh/xxh_xxh/xxh.py:440: SyntaxWarning: invalid escape sequence '\+'
  g = re.match(f'^({self.package_name_regex})\+({self.supported_source_types_regex})\+(.+)$', package_name)
xxh/xxh_xxh/xxh.py:440: SyntaxWarning: invalid escape sequence '\+'
  g = re.match(f'^({self.package_name_regex})\+({self.supported_source_types_regex})\+(.+)$', package_name)
```
